### PR TITLE
6 body container positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,5 +7,14 @@
     <link rel="stylesheet" href="styles.css" />
     <script type="module" src="script.js"></script>
   </head>
-  <body></body>
+  <body>
+
+    <section class="artboard">
+      <a>1</a>
+      <a>2</a>
+      <a>3</a>
+      <a>4</a>
+    </section>
+
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
   <body>
 
     <section class="artboard">
-      <a>1</a>
-      <a>2</a>
-      <a>3</a>
-      <a>4</a>
+      <a></a>
+      <a></a>
+      <a></a>
+      <a></a>
     </section>
 
   </body>

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,7 @@
 }
 
 .artboard a {
-    background-color: red; /* remove later and replace with background-image */
+    /* TODO: make code production ready. background-color: red; /* remove later and replace with background-image */
     border: 1px solid #F1C40F;
     width: 209px;
     height: 290px;
@@ -26,6 +26,5 @@
 @media screen and (min-width: 1024px) {
     .artboard {
         grid-template-columns: auto auto auto auto;
-        column-gap: 24px;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,31 @@
+.artboard {
+    display: grid;
+    grid-template-columns: auto auto;
+    justify-content: center;
+    column-gap: 24px;
+    row-gap: 24px;
+    margin: 36px;
+}
+
+.artboard a {
+    background-color: red; /* remove later and replace with background-image */
+    border: 1px solid #F1C40F;
+    width: 209px;
+    height: 290px;
+}
+
+/* If the screen is too narrow, the artboard blocks will smoosh into one column*/
+@media screen and (max-width: 480px) {
+    .artboard {
+        grid-template-columns: auto;
+    }
+}
+
+/* If the screen is wide enough, the block will spread out */
+/* although, I did just choose min-width number somewhat arbitrarily */
+@media screen and (min-width: 1024px) {
+    .artboard {
+        grid-template-columns: auto auto auto auto;
+        column-gap: 24px;
+    }
+}


### PR DESCRIPTION
This PR implements the 4-panel artboard section of the page. If the page is viewed with a tablet sized screen, the elements will appear in a 2x2 grid. If the screen is substantially larger, all four elements are placed on a single row, and if the screen is restrictively narrow, the elements will fill in to one column.

Feature was implemented using the CSS grid capability. Flexbox was tried first, but found to be not quite suitable for this scenario.

The feature addition took about 20 minutes.

Element sizes are pixel-perfect as per project specifications.

This PR solves Issue #6 